### PR TITLE
Disable npm scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
This disables the running of postinstall and preinstall script in package.json files, providing us better security by not allowing packages to run potentially malicious scripts in our environments.

It may break some developer tools, but let's try it out and see if that happens