### PR TITLE
ci: migrate to Blacksmith runners

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   check-dist:
     name: Check dist/
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
 
     steps:
       - name: Checkout

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
 
     steps:
       - uses: release-drafter/release-drafter@v6
@@ -25,7 +25,7 @@ jobs:
 
   check_labels:
     name: Validate Labels
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: update_release
     if: ${{ github.event_name == 'pull_request' }}
     permissions:


### PR DESCRIPTION
Migrates all GitHub-hosted runners in this repo to [Blacksmith](https://blacksmith.sh).

`runs-on: ubuntu-latest` → `blacksmith-2vcpu-ubuntu-2404` (2 vCPU Blacksmith instance), matching the org convention already used in `MentionMe` and `app.mention-me.com`.

Files changed: .github/workflows/check-dist.yml .github/workflows/ci.yml .github/workflows/release-drafter.yml 

Part of the org-wide move off GitHub-hosted runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SzLWqXuUFndaLsv3MKgRqJ