### PR TITLE
chore: CODEOWNERS team ownership sweep

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mention-me/partnerships
+* @mention-me/backend


### PR DESCRIPTION
Standardise code ownership across the org.

Adds/normalises `CODEOWNERS` so every repo has a team-based `*` default owner and legacy/ghost team tokens are retired (Stage 3 of the teams/permissions rollout).

Auto-generated sweep.